### PR TITLE
[CONTRACTS] [FIX] Make constructors' arguments as struct

### DIFF
--- a/contracts/contracts/common/CommonStructs.sol
+++ b/contracts/contracts/common/CommonStructs.sol
@@ -19,5 +19,10 @@ library CommonStructs {
         uint endTimestamp;
     }
 
-
+    struct ConstructorArgs {
+        address sideBridgeAddress; address relayAddress;
+        address[] tokenThisAddresses; address[] tokenSideAddresses;
+        uint fee; address payable feeRecipient;
+        uint timeframeSeconds; uint lockTime; uint minSafetyBlocks;
+    }
 }

--- a/contracts/contracts/contracts_for_tests/AmbBridgeTest.sol
+++ b/contracts/contracts/contracts_for_tests/AmbBridgeTest.sol
@@ -6,14 +6,9 @@ import "../common/CommonStructs.sol";
 
 contract AmbBridgeTest is AmbBridge {
     constructor(
-        address _sideBridgeAddress, address relayAddress,
-        address[] memory tokenThisAddresses, address[] memory tokenSideAddresses,
-        uint fee_, address payable feeRecipient_, uint timeframeSeconds_, uint lockTime_, uint minSafetyBlocks_
+        CommonStructs.ConstructorArgs memory args
     )
-    AmbBridge(_sideBridgeAddress, relayAddress,
-        tokenThisAddresses, tokenSideAddresses,
-        fee_, feeRecipient_, timeframeSeconds_, lockTime_, minSafetyBlocks_
-    ) {}
+    AmbBridge(args) {}
 
     function getLockedTransferTest(uint event_id, uint index) public view returns (address, address, uint) {
         CommonStructs.Transfer storage t = lockedTransfers[event_id].transfers[index];

--- a/contracts/contracts/eth/AmbBridge.sol
+++ b/contracts/contracts/eth/AmbBridge.sol
@@ -3,18 +3,17 @@ pragma solidity 0.8.6;
 
 import "../common/CommonBridge.sol";
 import "../common/checks/CheckPoW.sol";
+import "../common/CommonStructs.sol";
+
 
 contract AmbBridge is CommonBridge, CheckPoW {
     constructor(
-        address _sideBridgeAddress, address relayAddress,
-        address[] memory tokenThisAddresses, address[] memory tokenSideAddresses,
-        uint fee_, address payable feeRecipient_,
-        uint timeframeSeconds_, uint lockTime_, uint minSafetyBlocks_
+        CommonStructs.ConstructorArgs memory args
     )
-    CommonBridge(_sideBridgeAddress, relayAddress,
-                 tokenThisAddresses, tokenSideAddresses,
-                 fee_, feeRecipient_,
-                 timeframeSeconds_, lockTime_, minSafetyBlocks_)
+    CommonBridge(args.sideBridgeAddress, args.relayAddress,
+                 args.tokenThisAddresses, args.tokenSideAddresses,
+                 args.fee, args.feeRecipient,
+                 args.timeframeSeconds, args.lockTime, args.minSafetyBlocks)
     {
 
         // relay uses this event to know from what moment to synchronize the validator set;

--- a/contracts/contracts/eth/EthBridge.sol
+++ b/contracts/contracts/eth/EthBridge.sol
@@ -4,24 +4,22 @@ pragma solidity 0.8.6;
 import "hardhat/console.sol";
 import "../common/CommonBridge.sol";
 import "../common/checks/CheckAura.sol";
+import "../common/CommonStructs.sol";
 
 
 contract EthBridge is CommonBridge, CheckAura {
     address validatorSetAddress;
 
     constructor(
-        address _sideBridgeAddress, address relayAddress,
-        address[] memory tokenThisAddresses, address[] memory tokenSideAddresses,
-        uint fee_, address payable feeRecipient_,
-        uint timeframeSeconds_, uint lockTime_, uint minSafetyBlocks_,
+        CommonStructs.ConstructorArgs memory args,
         address[] memory initialValidators,
         address validatorSetAddress_
     )
     CommonBridge(
-        _sideBridgeAddress, relayAddress,
-        tokenThisAddresses, tokenSideAddresses,
-        fee_, feeRecipient_,
-        timeframeSeconds_, lockTime_, minSafetyBlocks_
+        args.sideBridgeAddress, args.relayAddress,
+        args.tokenThisAddresses, args.tokenSideAddresses,
+        args.fee, args.feeRecipient,
+        args.timeframeSeconds, args.lockTime, args.minSafetyBlocks
     )
     CheckAura(initialValidators)
     {

--- a/contracts/deploy/AmbBridge.ts
+++ b/contracts/deploy/AmbBridge.ts
@@ -1,35 +1,35 @@
-import {HardhatRuntimeEnvironment} from "hardhat/types";
-import {DeployFunction} from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  if (hre.network.name !== 'hardhat' && hre.network.name !== 'amb') return
-  const {owner} = await hre.getNamedAccounts();
+  if (hre.network.name !== "hardhat" && hre.network.name !== "amb") return;
+  const { owner } = await hre.getNamedAccounts();
   await hre.deployments.deploy("AmbBridge", {
     from: owner,
     args: [
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe", // _sideBridgeAddress
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe", // relayAddress
-      [
-        "0x195c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x395c2707319ad4beca6b5bb4086617fd6f240cfe"
-      ], // tokenThisAddresses
-      [
-        "0x495c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x595c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x695c2707319ad4beca6b5bb4086617fd6f240cfe"
-      ], // tokenSideAddresses
-      1000, // fee
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",  // feeRecipient
-      14400, // timeframeSeconds
-      1000, // lockTime
-      10 // minSafetyBlocks
+      {
+        sideBridgeAddress: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        relayAddress: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        tokenThisAddresses: [
+          "0x195c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x395c2707319ad4beca6b5bb4086617fd6f240cfe",
+        ],
+        tokenSideAddresses: [
+          "0x495c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x595c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x695c2707319ad4beca6b5bb4086617fd6f240cfe",
+        ],
+        fee: 1000,
+        feeRecipient: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        timeframeSeconds: 14400,
+        lockTime: 1000,
+        minSafetyBlocks: 10,
+      },
     ],
     log: true,
   });
 };
-
-
 
 export default func;
 func.tags = ["ambbridge"];

--- a/contracts/deploy/AmbBridgeTest.ts
+++ b/contracts/deploy/AmbBridgeTest.ts
@@ -1,35 +1,35 @@
-import {HardhatRuntimeEnvironment} from "hardhat/types";
-import {DeployFunction} from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  if (hre.network.name !== 'hardhat' && hre.network.name !== 'amb') return
-  const {owner} = await hre.getNamedAccounts();
+  if (hre.network.name !== "hardhat" && hre.network.name !== "amb") return;
+  const { owner } = await hre.getNamedAccounts();
   await hre.deployments.deploy("AmbBridgeTest", {
     from: owner,
     args: [
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",  // _sideBridgeAddress
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",  // relayAddress
-      [
-        "0x195c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x395c2707319ad4beca6b5bb4086617fd6f240cfe"
-      ],  // tokenThisAddresses
-      [
-        "0x495c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x595c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x695c2707319ad4beca6b5bb4086617fd6f240cfe"
-      ],  // tokenSideAddresses
-      1000,  // fee
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",  // feeRecipient
-      14400,  // timeframeSeconds
-      1000,  // lockTime
-      10  // minSafetyBlocks
+      {
+        sideBridgeAddress: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        relayAddress: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        tokenThisAddresses: [
+          "0x195c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x395c2707319ad4beca6b5bb4086617fd6f240cfe",
+        ],
+        tokenSideAddresses: [
+          "0x495c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x595c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x695c2707319ad4beca6b5bb4086617fd6f240cfe",
+        ],
+        fee: 1000,
+        feeRecipient: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        timeframeSeconds: 14400,
+        lockTime: 1000,
+        minSafetyBlocks: 10,
+      },
     ],
     log: true,
   });
 };
-
-
 
 export default func;
 func.tags = ["ambbridgetest"];

--- a/contracts/deploy/EthBridge.ts
+++ b/contracts/deploy/EthBridge.ts
@@ -1,40 +1,42 @@
-import {HardhatRuntimeEnvironment} from "hardhat/types";
-import {DeployFunction} from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  if (hre.network.name !== 'hardhat' && hre.network.name != 'rinkeby') return
-  const {owner} = await hre.getNamedAccounts();
+  if (hre.network.name !== "hardhat" && hre.network.name != "rinkeby") return;
+  const { owner } = await hre.getNamedAccounts();
 
   await hre.deployments.deploy("EthBridge", {
     contract: "EthBridge",
     from: owner,
     args: [
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe", // _sideBridgeAddress
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe", // relayAddress
+      {
+        sideBridgeAddress: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        relayAddress: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        tokenThisAddresses: [
+          "0x195c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x395c2707319ad4beca6b5bb4086617fd6f240cfe",
+        ],
+        tokenSideAddresses: [
+          "0x495c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x595c2707319ad4beca6b5bb4086617fd6f240cfe",
+          "0x695c2707319ad4beca6b5bb4086617fd6f240cfe",
+        ],
+        fee: 1000,
+        feeRecipient: "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
+        timeframeSeconds: 14400,
+        lockTime: 1000,
+        minSafetyBlocks: 10,
+      },
       [
-        "0x195c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x395c2707319ad4beca6b5bb4086617fd6f240cfe"
-      ], // tokenThisAddresses
-      [
-        "0x495c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x595c2707319ad4beca6b5bb4086617fd6f240cfe",
-        "0x695c2707319ad4beca6b5bb4086617fd6f240cfe"
-      ], // tokenSideAddresses
-      1000, // fee
-      "0x295c2707319ad4beca6b5bb4086617fd6f240cfe",  // feeRecipient
-      14400, // timeframeSeconds
-      1000, // lockTime
-      10, // minSafetyBlocks
-      ["0x11112707319ad4beca6b5bb4086617fd6f240cfe", "0x22222707319ad4beca6b5bb4086617fd6f240cfe"],
-      "0x495c2707319ad4beca6b5bb4086617fd6f240cfe"  // validatorSetAddress
+        "0x11112707319ad4beca6b5bb4086617fd6f240cfe",
+        "0x22222707319ad4beca6b5bb4086617fd6f240cfe",
+      ], // initial validators
+      "0x495c2707319ad4beca6b5bb4086617fd6f240cfe", // validatorSetAddress_
     ],
     log: true,
   });
-
 };
-
-
 
 export default func;
 func.tags = ["ethbridge"];


### PR DESCRIPTION
Solidity doesn't allow us to compile contracts with >16 local variables. It throws an error:

```
CompilerError: Stack too deep when compiling inline assembly: Variable headStart is 1 slot(s) too deep inside the stack.
```

We can extract those arguments into a struct to solve this problem.

Also, the commit contains come refactoring in deploy scripts and in testing contracts.