### PR TITLE
[RELAY] [FIX] Return `ErrEpochDataFileNotFound` if file not found instead of `nil`

### DIFF
--- a/relay/internal/networks/eth/epoch.go
+++ b/relay/internal/networks/eth/epoch.go
@@ -72,7 +72,7 @@ func (b *Bridge) checkEpochDataFile(epoch uint64) error {
 	b.logger.Debug().Msgf("Checking '%d.json' epoch data file...", epoch)
 	_, err := os.Stat(fmt.Sprintf(epochDataFilePath, epoch))
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
+		return ErrEpochDataFileNotFound
 	}
 	return err
 }


### PR DESCRIPTION
Partly revert commit ad2a293bb7ae0c476c5beaf014161d8a3dbda025.