### PR TITLE
feat(relay/fees): add `amount` to signature

### DIFF
--- a/relay/internal/fee_api/handlers.go
+++ b/relay/internal/fee_api/handlers.go
@@ -87,7 +87,7 @@ func (p *FeeAPI) getFees(req reqParams) (*result, *AppError) {
 	}, nil
 }
 
-func buildMessage(tokenAddress common.Address, transferFee *big.Int, bridgeFee *big.Int, amount *big.Int) []byte {
+func buildMessage(tokenAddress common.Address, transferFee, bridgeFee, amount *big.Int) []byte {
 	// tokenAddress + timestamp + transferFee + bridgeFee
 
 	var data bytes.Buffer


### PR DESCRIPTION
For the case when the user can bypass adding percent to the bridge fee.