### PR TITLE
[RELAY/UNLOCK] [FIX] execution reverted 0x

### DIFF
--- a/relay/internal/service_unlock/unlock_transfers.go
+++ b/relay/internal/service_unlock/unlock_transfers.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const timeSleepBeforeUnlock = 2 * time.Second
+
 type UnlockTransfers struct {
 	bridge        networks.Bridge
 	watchValidity *service_watchdog.WatchTransfersValidity
@@ -86,6 +88,8 @@ func (b *UnlockTransfers) unlockOldTransfers() error {
 	if err := b.watchValidity.CheckOldLockedTransferFromId(oldestLockedEventId); err != nil {
 		return fmt.Errorf("checkOldLockedTransferFromId: %w", err)
 	}
+	b.logger.Info().Str("event_id", oldestLockedEventId.String()).Msgf("sleeping %s before unlocking...", timeSleepBeforeUnlock)
+	time.Sleep(timeSleepBeforeUnlock)
 	b.logger.Info().Str("event_id", oldestLockedEventId.String()).Msg("unlocking...")
 	err = b.unlockTransfers()
 	if err != nil {


### PR DESCRIPTION
Sometimes unlocking a transfer may fail with the contract error **execution reverted: 0x**, but at the second time it mines successfully.

We think there's some kind of out of sync, so I added 2 seconds sleep before unlocking.