### PR TITLE
fix(relay/tglogger): rest fields can be not only string

### DIFF
--- a/relay/internal/logger/telegram/hook.go
+++ b/relay/internal/logger/telegram/hook.go
@@ -51,7 +51,7 @@ func BuildMessage(l *logger.ExtLog) string {
 		msg += fmt.Sprintf(fieldsFormat, "service", replacer.Replace(l.Service))
 	}
 	for _, field := range fields {
-		msg += fmt.Sprintf(fieldsFormat, field, replacer.Replace(l.Rest[field].(string)))
+		msg += fmt.Sprintf(fieldsFormat, field, replacer.Replace(fmt.Sprintf("%v", l.Rest[field])))
 	}
 	if l.Error != "" {
 		msg += fmt.Sprintf(fieldsFormat, "error", replacer.Replace(l.Error))


### PR DESCRIPTION
Type conversion from interface to string will cause a panic if the real type of field is boolean for example.
So we should use `fmt.Sprintf` for convert any type to string.